### PR TITLE
Update expose-intro.html

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html
@@ -112,9 +112,13 @@ description: |-
 				<p>Create an environment variable called <tt>NODE_PORT</tt> that has the value of the Node port assigned:</p>
 				<p><code><b>export NODE_PORT="$(kubectl get services/kubernetes-bootcamp -o go-template='{{(index .spec.ports 0).nodePort}}')"</b></code><br />
 				<code><b>echo "NODE_PORT=$NODE_PORT"</b></code></p>
-				<p>Now we can test that the app is exposed outside of the cluster using <code>curl</code>, the IP address of the Node and the externally exposed port:</p>
-				<p><code><b>curl http://"$(minikube ip):$NODE_PORT"</b></code></p>
-				<p>And we get a response from the server. The Service is exposed.</p>
+        <p>In order to expose this port to the machine you are working on you will need to create a tunnel using the following command:</p>
+        <p><code><b>minikube service kubernetes-bootcamp</b></code></p>
+        <p>The tunnel will automatically open in your browser. Your terminal should show you the tunnel URL used as well.</p>
+        <p>You can connect to it using <code><b>curl</b></code> as follows:</p>
+				<p><code><b>curl http://"127.0.0.1:TUNNEL_PORT"</b></code></p>
+        <p>Where <code><b>TUNNEL_PORT</b></code>is the port assigned by minikube when setting up the tunnel.</p>
+				<p>We get a response from the server. The Service is exposed.</p>
 			</div>
 		</div>
 


### PR DESCRIPTION
minikube isn't exposed under `minikube ip` on the local machine as this ip is the ip of the host that minikube runs on.

Without additional setup within the hypervisor (i.e. Docker) it's not possible to connect to minikube in a way described in this tutorial.

Setting up tunneling of the service resolves this issue.

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
